### PR TITLE
Add send_to_prompt function with examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ vim.api.nvim_create_user_command("AmpSend", function(opts)
     print("Please provide a message to send")
     return
   end
-  
+
   local amp_message = require("amp.message")
   amp_message.send_message(message)
 end, {
@@ -67,12 +67,47 @@ vim.api.nvim_create_user_command("AmpSendBuffer", function(opts)
   local buf = vim.api.nvim_get_current_buf()
   local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
   local content = table.concat(lines, "\n")
-  
+
   local amp_message = require("amp.message")
   amp_message.send_message(content)
 end, {
   nargs = "?",
   desc = "Send current buffer contents to Amp",
+})
+
+-- Add selected text directly to prompt
+vim.api.nvim_create_user_command("AmpPromptSelection", function(opts)
+  local lines = vim.api.nvim_buf_get_lines(0, opts.line1 - 1, opts.line2, false)
+  local text = table.concat(lines, "\n")
+
+  local amp_message = require("amp.message")
+  amp_message.send_to_prompt(text)
+end, {
+  range = true,
+  desc = "Add selected text to Amp prompt",
+})
+
+-- Add file+selection reference to prompt
+vim.api.nvim_create_user_command("AmpPromptRef", function(opts)
+  local bufname = vim.api.nvim_buf_get_name(0)
+  if bufname == "" then
+    print("Current buffer has no filename")
+    return
+  end
+
+  local relative_path = vim.fn.fnamemodify(bufname, ":.")
+  local ref = "@" .. relative_path
+  if opts.line1 ~= opts.line2 then
+    ref = ref .. "#L" .. opts.line1 .. "-" .. opts.line2
+  elseif opts.line1 > 1 then
+    ref = ref .. "#L" .. opts.line1
+  end
+
+  local amp_message = require("amp.message")
+  amp_message.send_to_prompt(ref)
+end, {
+  range = true,
+  desc = "Add file reference (with selection) to Amp prompt",
 })
 ```
 

--- a/lua/amp/message.lua
+++ b/lua/amp/message.lua
@@ -27,4 +27,27 @@ function M.send_message(message)
 	return success
 end
 
+---Send a message to append to the prompt field in the IDE
+---@param message string The message to append to the prompt
+---@return boolean success Whether message was sent successfully
+function M.send_to_prompt(message)
+	local amp = require("amp")
+	if not amp.state.server then
+		logger.warn("message", "Server is not running - start it first with :AmpStart")
+		return false
+	end
+
+	local success = amp.state.server.broadcast_ide({
+		appendToPrompt = { message = message },
+	})
+
+	if success then
+		logger.debug("message", "Message appended to prompt")
+	else
+		logger.error("message", "Failed to append message to prompt")
+	end
+
+	return success
+end
+
 return M


### PR DESCRIPTION
Allows users to send messages directly to the connected CLI's prompt field, as requested in https://github.com/sourcegraph/amp.nvim/issues/6

Allows for some more complex message crafting that's not necessarily tied to the current Neovim session's lifespan