### PR TITLE
fix remove of client on disconnect

### DIFF
--- a/lua/amp/server/init.lua
+++ b/lua/amp/server/init.lua
@@ -92,7 +92,7 @@ function M.start(auth_token)
 			end, 50)
 		end,
 		on_disconnect = function(client, code, reason)
-			table.remove(M.state.clients, client.id)
+			M.state.clients[client.id] = nil
 			logger.debug(
 				"server",
 				"IDE client disconnected:",


### PR DESCRIPTION
This is was my bad. `table.remove` does not exist.