### PR TITLE
chore: migrate from push to pull based diagnostics

### DIFF
--- a/lua/amp/diagnostics.lua
+++ b/lua/amp/diagnostics.lua
@@ -2,53 +2,11 @@
 ---@module 'amp.diagnostics'
 local M = {}
 
-local logger = require("amp.logger")
-
-M.state = {
-	diagnostics_enabled = false,
-	latest_diagnostics = {},
-}
-
----Enable diagnostics tracking
----@param server table The server object to use for broadcasting
-function M.enable(server)
-	if M.state.diagnostics_enabled then
-		return
-	end
-
-	M.state.diagnostics_enabled = true
-	M.server = server
-
-	M._create_autocommands()
-	logger.debug("diagnostics", "Diagnostics tracking enabled")
-end
-
-function M.disable()
-	if not M.state.diagnostics_enabled then
-		return
-	end
-
-	M.state.diagnostics_enabled = false
-	M._clear_autocommands()
-
-	M.state.latest_diagnostics = {}
-	M.server = nil
-
-	logger.debug("diagnostics", "Diagnostics tracking disabled")
-end
-
----Check if diagnostics has changed
----@param new_diagnostics vim.Diagnostic
----@return boolean
-function M.have_diagnostics_changed(new_diagnostics)
-	return vim.inspect(M.state.latest_diagnostics) ~= vim.inspect(new_diagnostics)
-end
-
----@alias JetBrainsSeverity "ERROR" | "WARNING" | "WEAK_WARNING" | "INFO"
+---@alias DiagnosticSeverity "ERROR" | "WARNING" | "WEAK_WARNING" | "INFO"
 
 ---@param severity vim.diagnostic.Severity
----@return JetBrainsSeverity
-function M._vim_severity_to_jetbrains(severity)
+---@return DiagnosticSeverity
+function M._vim_severity_to_protocol(severity)
 	if severity == vim.diagnostic.severity.ERROR then
 		return "ERROR"
 	elseif severity == vim.diagnostic.severity.WARN then
@@ -56,8 +14,6 @@ function M._vim_severity_to_jetbrains(severity)
 	elseif severity == vim.diagnostic.severity.INFO then
 		return "INFO"
 	elseif severity == vim.diagnostic.severity.HINT then
-		-- The JetBrains protocol doesn't recognize "HINT", so we
-		-- use "WEAK_WARNING" instead
 		return "WEAK_WARNING"
 	end
 
@@ -70,17 +26,23 @@ end
 ---@field endLine number
 ---@field endCharacter number
 
----@class JetBrainsDiagnostic
+---@class ProtocolDiagnostic
 ---@field range Range
----@field severity JetBrainsSeverity
+---@field severity DiagnosticSeverity
 ---@field description string
 ---@field lineContent string
 ---@field startOffset number
 ---@field endOffset number
 
 ---@param diagnostic vim.Diagnostic
----@return JetBrainsDiagnostic
-function M._vim_diagnostic_to_jetbrains(diagnostic)
+---@return ProtocolDiagnostic
+function M._vim_diagnostic_to_protocol(diagnostic)
+	local line_content = ""
+	local ok, lines = pcall(vim.api.nvim_buf_get_lines, diagnostic.bufnr, diagnostic.lnum, diagnostic.lnum + 1, false)
+	if ok and lines and lines[1] then
+		line_content = lines[1]
+	end
+
 	return {
 		range = {
 			startLine = diagnostic.lnum,
@@ -88,61 +50,82 @@ function M._vim_diagnostic_to_jetbrains(diagnostic)
 			endLine = diagnostic.end_lnum,
 			endCharacter = diagnostic.end_col,
 		},
-		severity = M._vim_severity_to_jetbrains(diagnostic.severity),
+		severity = M._vim_severity_to_protocol(diagnostic.severity),
 		description = diagnostic.message,
-		lineContent = vim.api.nvim_buf_get_lines(diagnostic.bufnr, diagnostic.lnum, diagnostic.lnum + 1, false)[1],
+		lineContent = line_content,
 		startOffset = diagnostic.col,
 		endOffset = diagnostic.end_col,
 	}
 end
 
-function M.broadcast_diagnostics(force)
-	if not M.state.diagnostics_enabled or not M.server then
-		return
+---Get diagnostics for a specific path (file or directory)
+---@param path string Absolute path to file or directory
+---@return table entries Array of diagnostic entries
+function M.get_diagnostics(path)
+	local uv = vim.loop
+	local stat = uv.fs_stat(path)
+
+	if not stat then
+		return {}
 	end
 
-	local diagnostics = vim.diagnostic.get(nil)
+	local entries = {}
 
-	if force or M.have_diagnostics_changed(diagnostics) then
-		M.state.latest_diagnostics = diagnostics
-		local diagnostics_by_bufnr = {}
-		for _, value in ipairs(diagnostics) do
-			if not diagnostics_by_bufnr[value.bufnr] then
-				diagnostics_by_bufnr[value.bufnr] = {}
+	if stat.type == "file" then
+		-- Single file request - get diagnostics for this specific buffer
+		local abs_path = vim.fn.fnamemodify(path, ":p")
+		local uri = "file://" .. abs_path
+		local bufnr = vim.fn.bufnr("^" .. abs_path .. "$")
+		
+		local diagnostics = {}
+		if bufnr ~= -1 then
+			local raw_diagnostics = vim.diagnostic.get(bufnr)
+			for _, diag in ipairs(raw_diagnostics) do
+				table.insert(diagnostics, M._vim_diagnostic_to_protocol(diag))
 			end
-			table.insert(diagnostics_by_bufnr[value.bufnr], M._vim_diagnostic_to_jetbrains(value))
 		end
 
-		for idiagnostic, diagnostic in pairs(diagnostics_by_bufnr) do
-			local name = "file://" .. vim.api.nvim_buf_get_name(idiagnostic)
-			local diagnostics_message = {
-				diagnosticsDidChange = {
-					uri = name,
-					diagnostics = diagnostic,
-				},
-			}
-			M.server.broadcast_ide(diagnostics_message)
+		table.insert(entries, {
+			uri = uri,
+			diagnostics = diagnostics,
+		})
+	elseif stat.type == "directory" then
+		-- Directory request - get diagnostics for all buffers in this directory
+		local abs_dir = vim.fn.fnamemodify(path, ":p")
+		-- Ensure directory path ends with /
+		if not abs_dir:match("/$") then
+			abs_dir = abs_dir .. "/"
+		end
+
+		-- Get diagnostics from all buffers
+		local all_diagnostics = vim.diagnostic.get(nil)
+		local diagnostics_by_uri = {}
+
+		for _, diag in ipairs(all_diagnostics) do
+			local ok, buf_name = pcall(vim.api.nvim_buf_get_name, diag.bufnr)
+			if ok and buf_name and buf_name ~= "" then
+				local abs_buf_name = vim.fn.fnamemodify(buf_name, ":p")
+				-- Check if this file is in the requested directory
+				-- Must match directory prefix and have a path separator after (or be exact match)
+				if abs_buf_name:sub(1, #abs_dir) == abs_dir then
+					local uri = "file://" .. abs_buf_name
+					if not diagnostics_by_uri[uri] then
+						diagnostics_by_uri[uri] = {}
+					end
+					table.insert(diagnostics_by_uri[uri], M._vim_diagnostic_to_protocol(diag))
+				end
+			end
+		end
+
+		for uri, diag_list in pairs(diagnostics_by_uri) do
+			table.insert(entries, {
+				uri = uri,
+				diagnostics = diag_list,
+			})
 		end
 	end
-end
 
----Create autocommands for diagnostics tracking
-function M._create_autocommands()
-	local group = vim.api.nvim_create_augroup("AmpDiagnostics", { clear = true })
-
-	vim.api.nvim_create_autocmd("DiagnosticChanged", {
-		group = group,
-		callback = function(_)
-			vim.defer_fn(function()
-				M.broadcast_diagnostics()
-			end, 10)
-		end,
-	})
-end
-
----Clear autocommands
-function M._clear_autocommands()
-	vim.api.nvim_clear_autocmds({ group = "AmpDiagnostics" })
+	return entries
 end
 
 return M

--- a/lua/amp/diagnostics.lua
+++ b/lua/amp/diagnostics.lua
@@ -76,7 +76,7 @@ function M.get_diagnostics(path)
 		local abs_path = vim.fn.fnamemodify(path, ":p")
 		local uri = "file://" .. abs_path
 		local bufnr = vim.fn.bufnr("^" .. abs_path .. "$")
-		
+
 		local diagnostics = {}
 		if bufnr ~= -1 then
 			local raw_diagnostics = vim.diagnostic.get(bufnr)

--- a/lua/amp/init.lua
+++ b/lua/amp/init.lua
@@ -178,9 +178,7 @@ function M._enable_ide_features(server)
 	local visible_files = require("amp.visible_files")
 	visible_files.enable(server)
 
-	-- Enable diagnostics tracking
-	local diagnostics = require("amp.diagnostics")
-	diagnostics.enable(server)
+	-- Diagnostics are pull-based via getDiagnostics requests (no setup needed)
 
 	-- Send initial plugin metadata
 	vim.defer_fn(function()

--- a/lua/amp/init.lua
+++ b/lua/amp/init.lua
@@ -217,7 +217,10 @@ function M._create_commands()
 	vim.api.nvim_create_user_command("AmpStatus", function()
 		if M.state.server and M.state.port then
 			local connection_status = M.state.connected and "connected" or "waiting for clients"
-			logger.info("command", "Server is running on port " .. tostring(M.state.port) .. " (" .. connection_status .. ")")
+			logger.info(
+				"command",
+				"Server is running on port " .. tostring(M.state.port) .. " (" .. connection_status .. ")"
+			)
 
 			-- Show current visible files and selection for debugging
 			local visible_files = require("amp.visible_files")

--- a/lua/amp/lockfile.lua
+++ b/lua/amp/lockfile.lua
@@ -1,7 +1,5 @@
 local M = {}
 
-
-
 -- Get the user's home directory. The fallback handles edge cases where
 -- vim.loop.os_homedir() returns nil (missing HOME/USERPROFILE env vars,
 -- broken containers, permission issues), but this is unlikely without
@@ -20,7 +18,7 @@ local function get_data_home()
 
 	local sys = vim.loop.os_uname().sysname
 	local standard_dir = vim.fs.joinpath(homedir(), ".local", "share")
-	
+
 	-- Match amp repository core/src/common/dirs.ts logic:
 	-- On Windows/macOS: use standard dir (~/.local/share)
 	-- On Linux: use XDG_DATA_HOME if set, otherwise standard dir

--- a/lua/amp/server/init.lua
+++ b/lua/amp/server/init.lua
@@ -345,6 +345,32 @@ function M._handle_message(client, message)
 		return
 	end
 
+	-- Handle getDiagnostics request
+	if request.getDiagnostics then
+		local path = request.getDiagnostics.path
+
+		if not path then
+			local error_response = ide.wrap_error(id, {
+				code = -32602,
+				message = "Invalid params",
+				data = "getDiagnostics requires path parameter",
+			})
+			M.send_ide(client, error_response)
+			return
+		end
+
+		local diagnostics = require("amp.diagnostics")
+		local entries = diagnostics.get_diagnostics(path)
+
+		local response = ide.wrap_response(id, {
+			getDiagnostics = {
+				entries = entries,
+			},
+		})
+		M.send_ide(client, response)
+		return
+	end
+
 	-- Unknown request
 	local error_response = ide.wrap_error(id, {
 		code = -32601,
@@ -413,9 +439,6 @@ function M._send_state()
 
 	local selection = require("amp.selection")
 	selection.update_and_broadcast(true)
-
-	local diagnostics = require("amp.diagnostics")
-	diagnostics.broadcast_diagnostics(true)
 end
 
 return M


### PR DESCRIPTION
Amp CLI, JetBrains, and VSCode have also been updated to not cache diagnostics and push them to the CLI anymore, but rather respond to getDiagnostics requests.

This PR updates amp.nvim accordingly.