### PR TITLE
fix: write files natively

### DIFF
--- a/lua/amp/server/init.lua
+++ b/lua/amp/server/init.lua
@@ -329,7 +329,7 @@ function M._handle_message(client, message)
 			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 
 			-- Write buffer to file
-			vim.api.nvim_buf_call(bufnr, vim.cmd.write)
+			vim.api.nvim_buf_call(bufnr, vim.cmd.update)
 		end)
 
 		if success then

--- a/lua/amp/server/init.lua
+++ b/lua/amp/server/init.lua
@@ -328,24 +328,8 @@ function M._handle_message(client, message)
 			-- Replace entire buffer content
 			vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
 
-			-- Use async file writing with vim.loop
-			local uv = vim.loop
-			local fd = uv.fs_open(full_path, "w", 438) -- 438 = 0666 in decimal
-			if not fd then
-				error("Cannot open file for writing")
-			end
-
-			-- Ensure file ends with newline (standard POSIX convention)
-			local content_to_write = fullContent
-			if content_to_write:sub(-1) ~= "\n" then
-				content_to_write = content_to_write .. "\n"
-			end
-
-			uv.fs_write(fd, content_to_write, 0)
-			uv.fs_close(fd)
-
-			-- Mark buffer as not modified since we just saved it
-			vim.api.nvim_set_option_value("modified", false, { buf = bufnr })
+			-- Write buffer to file
+			vim.api.nvim_buf_call(bufnr, vim.cmd.write)
 		end)
 
 		if success then


### PR DESCRIPTION
The current implementation bypasses Neovim's native way to save files. I'm not sure there's a good reason for this. It ignores autocommands on buffer writes, and in my case conflicts with an auto-save config I use:

```lua
vim.api.nvim_create_autocmd({'TextChanged', 'InsertLeave'}, {
  callback = function (ev)
    if vim.bo.modified then
      local file = vim.api.nvim_buf_get_name(ev.buf)
      if file ~= "" and vim.uv.fs_stat(file) then
        vim.schedule(function () vim.cmd 'silent update' end)
      end
    end
  end
})
```

I think what's happening is that my autocmd writes the file first, then amp.nvim writes it to disk, this causes Neovim to consider it changed on disk independently, and further changes trigger a confirmation prompt about writing to a file that changed on disk.